### PR TITLE
Added changes to connection retrieval in anticipation of changes in Shop 14

### DIFF
--- a/shopcasebaseclass/shopcasebaseclass.py
+++ b/shopcasebaseclass/shopcasebaseclass.py
@@ -623,6 +623,10 @@ class ShopCaseBaseClass:
         obj_types = shop.shop_api.GetObjectTypesInSystem()
         obj_names = shop.shop_api.GetObjectNamesInSystem()
 
+        # A number of connections are bidirectional and will be returned for both objects involved. Keep a set of
+        # added connections to avoid adding duplicate connections
+        added_connections = set([])
+
         for to_type, to_name in zip(obj_types, obj_names):
             valid_relation_types = shop.shop_api.GetValidRelationTypes(to_type)
             
@@ -631,6 +635,12 @@ class ShopCaseBaseClass:
                 
                 for order, r in enumerate(relations): # Enumerate to get "order"
                     from_type, from_name = obj_types[r], obj_names[r]
+
+                    # Skip the connection if it is bidirectional and has already been added by the other object involved
+                    reverse_connection_tuple = (to_type, to_name, from_type, from_name)
+                    if reverse_connection_tuple in added_connections:
+                        continue
+
                     connection = {
                         'from': from_name, 
                         'to': to_name,
@@ -641,6 +651,10 @@ class ShopCaseBaseClass:
                     if len(relations) > 1 and 'junction' in to_type:
                         connection['order'] = order
                     connections.append(connection)
+
+                    # Update set of seen connections
+                    connection_tuple = (from_type, from_name, to_type, to_name)
+                    added_connections.add(connection_tuple)
 
         return connections
 


### PR DESCRIPTION
Shop 14 will expose an array of "group"-objects like "cut_group" and "volume_constraint" in the API and allow the user to add members to such groups using the connect/relate procedure. Such relations are bidirectional in the sense that connecting a member to a group is equivalent to setting the group of the member, and the user is free to add the connection in whichever order they please. Shop also have some connections that are strictly directional like reservoir->plant. Furthermore, Shop 14 has gotten rid of most specific relation types. All connections, with the exception of reservoir->gate, is fully resolvable based on the types of the objects themselves. 

Shop 14 will allow you to add all bidirectional(logical) connections in any order, i.e. A connect B or B connect A, but an outcome of their true bidirectional nature and removal of relation types specifying "virtual directions" (like generator_of_plant and plant_of_generator) is that "input" and "output" does not make any for these connections. Thus, in Shop 14 you will get all "input" directional(physical) connections of object A and ALL bidirectional connections when retrieving "input" connections. This means that you will get all bidirectional connections twice if you ask all objects for their "input" connections

Ultimately, this means that you have to make some minor changes to the retrieval of connections in order to not add logical connections twice. The suggested change will also work for older versions of Shop. Feel free to change as much as you want, I simply wanted to provide you with some working code before the first trial versions of Shop 14 is released